### PR TITLE
Add filters to exclude internal/docs from nix derivation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -388,6 +388,7 @@
           src = builtins.path {
             path = ./.;
             name = "source";
+            filter = path: type: !builtins.match "internal/docs" path;
           };
 
           databaseFiles = pkgs.runCommand "database-files" {} ''


### PR DESCRIPTION
Add filter to exclude `internal/docs` from nix derivation.

* Modify `flake.nix` to add a filter in the `src` attribute using `builtins.path`.
* Exclude `internal/docs` directory from the nix derivation by adding a filter to the `src` attribute.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/conneroisu/conneroh.com/pull/163?shareId=140e21cf-db2c-4972-b18e-b7ef30040646).