### PR TITLE
Add path ignore to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -385,10 +385,9 @@
           force_https = true;
           processes = ["app"];
           version = self.shortRev or "dirty";
-          src = builtins.path {
-            path = ./.;
-            name = "source";
-          };
+          src = builtins.filterSource
+            (path: type: !(type == "directory" && baseNameOf path == "node_modules") && !(type == "directory" && baseNameOf path == "internal/data/docs"))
+            ./source-dir;
 
           databaseFiles = pkgs.runCommand "database-files" {} ''
             mkdir -p $out/root


### PR DESCRIPTION
Add path ignore for `src` attribute in `flake.nix` file.

* Add `builtins.filterSource` function for the `src` attribute.
* Filter out directories like `node_modules` and `internal/data/docs`.
* Set the path to `./source-dir`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/conneroisu/conneroh.com/pull/164?shareId=4554ed39-eac7-4edb-8e96-0ee24cfe6a66).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the build process to exclude the `node_modules` and `internal/data/docs` directories from the package source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->