### PR TITLE
Apply radial mask to banner previews

### DIFF
--- a/cmd/conneroh/components/items.templ
+++ b/cmd/conneroh/components/items.templ
@@ -22,11 +22,11 @@ templ ProjectItem(
 			{ attrs... }
 		>
 			<div class={ twerge.It("relative w-full") }>
-				@Image(
-					project.BannerPath,
-					project.Title,
-					twerge.It("w-full h-48 object-cover"),
-				)
+                                @Image(
+                                        project.BannerPath,
+                                        project.Title,
+                                        twerge.It("w-full h-48 object-cover box"),
+                                )
 			</div>
 			<div
 				class={ twerge.It("flex-grow flex p-6 flex-col") }
@@ -88,11 +88,11 @@ templ PostItem(post *assets.Post, attrs templ.Attributes) {
 			aria-label={ post.Title }
 			{ attrs... }
 		>
-			@Image(
-				post.BannerPath,
-				post.Title,
-				twerge.It("w-full h-48 object-cover"),
-			)
+                        @Image(
+                                post.BannerPath,
+                                post.Title,
+                                twerge.It("w-full h-48 object-cover box"),
+                        )
 			<div
 				class={ twerge.It("p-6") }
 			>
@@ -190,11 +190,11 @@ templ EmploymentItem(employment *assets.Employment, attrs templ.Attributes) {
 			aria-label={ employment.Title }
 			{ attrs... }
 		>
-			@Image(
-				employment.BannerPath,
-				employment.Title,
-				twerge.It("w-full h-48 object-cover"),
-			)
+                        @Image(
+                                employment.BannerPath,
+                                employment.Title,
+                                twerge.It("w-full h-48 object-cover box"),
+                        )
 			<div
 				class={ twerge.It("p-6") }
 			>

--- a/cmd/conneroh/views/employments.templ
+++ b/cmd/conneroh/views/employments.templ
@@ -14,11 +14,11 @@ templ Employment(
 		class={ twerge.It("px-4 mx-auto py-8 max-w-5xl") }
 	>
 		if employment.BannerPath != "" {
-			@components.Image(
-				employment.BannerPath,
-				employment.Title,
-				twerge.It("w-full md:h-96 rounded-lg object-cover shadow-md mb-8 h-64"),
-			)
+                        @components.Image(
+                                employment.BannerPath,
+                                employment.Title,
+                                twerge.It("w-full md:h-96 rounded-lg object-cover shadow-md mb-8 h-64 box"),
+                        )
 		}
 		<div
 			class={ twerge.It("bg-gray-800 rounded-lg mb-8 overflow-hidden p-6 shadow-lg") }

--- a/cmd/conneroh/views/posts.templ
+++ b/cmd/conneroh/views/posts.templ
@@ -14,11 +14,11 @@ templ Post(
 		class={ twerge.It("px-4 mx-auto py-8 max-w-5xl") }
 	>
 		if post.BannerPath != "" {
-			@components.Image(
-				post.BannerPath,
-				post.Title,
-				twerge.It("w-full md:h-96 rounded-lg object-cover shadow-md mb-8 h-64"),
-			)
+                        @components.Image(
+                                post.BannerPath,
+                                post.Title,
+                                twerge.It("w-full md:h-96 rounded-lg object-cover shadow-md mb-8 h-64 box"),
+                        )
 		}
 		<div
 			class={ twerge.It("bg-gray-800 rounded-lg mb-8 overflow-hidden p-6 shadow-lg") }

--- a/cmd/conneroh/views/projects.templ
+++ b/cmd/conneroh/views/projects.templ
@@ -13,11 +13,11 @@ templ Project(
 		class={ twerge.It("px-4 mx-auto py-8 max-w-5xl") }
 	>
 		if project.BannerPath != "" {
-			@components.Image(
-				project.BannerPath,
-				project.Title,
-				twerge.It("w-full md:h-96 object-center rounded-lg object-cover shadow-md mb-8 h-64 bg-gray-800"),
-			)
+                        @components.Image(
+                                project.BannerPath,
+                                project.Title,
+                                twerge.It("w-full md:h-96 object-center rounded-lg object-cover shadow-md mb-8 h-64 bg-gray-800 box"),
+                        )
 		}
 		<div
 			class={ twerge.It("bg-gray-800 rounded-lg mb-8 overflow-hidden p-6 shadow-lg") }

--- a/input.css
+++ b/input.css
@@ -1387,6 +1387,11 @@ div[style*="color:#f8f8f2;background-color:#272822"] td:last-child {
 	scrollbar-color: #555 #1e1e1e;
 }
 
+/* Banner mask styling */
+.box {
+        mask: radial-gradient(30px at top,#0000 calc(100% - 1px),#000) 50%/55.5px 100%;
+}
+
 /* Mobile responsive */
 @media (max-width: 768px) {
 	div[style*="color:#f8f8f2;background-color:#272822"] {


### PR DESCRIPTION
## Summary
- style banner preview images with `.box` mask
- include new `.box` class in CSS

## Testing
- `go test ./...` *(fails: undefined references in generated templ files)*
- `bun test:run` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843679cbac88333b60489f9efb55825