### PR TITLE
Fix vendor hash in flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -341,7 +341,7 @@
           {
             conneroh = pkgs.buildGoModule {
               inherit src version preBuild;
-              vendorHash = "sha256-447MwdXuirsxql/A+BvUoQHW+FhiWkfCtet4eyCa5qI=";
+              vendorHash = "sha256-NGpSBmz/Xlg6H/OS9Z9Gydzi8SSpwRzqQU4Oj9tss9I=";
               name = "conneroh.com";
               goSum = ./go.sum;
               subPackages = ["."];


### PR DESCRIPTION
## Summary
- update Go module vendor hash to match current dependencies

## Testing
- `go test ./...` *(fails: no required module provides package github.com/conneroisu/conneroh.com/cmd/conneroh/layouts)*
- `bun test` *(fails: ReferenceError: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6846e143d24c833391ccd0880cffef38