### PR TITLE
Fix flake vendor hash

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -341,7 +341,7 @@
           {
             conneroh = pkgs.buildGoModule {
               inherit src version preBuild;
-              vendorHash = "sha256-447MwdXuirsxql/A+BvUoQHW+FhiWkfCtet4eyCa5qI=";
+              vendorHash = "sha256-NGpSBmz/Xlg6H/OS9Z9Gydzi8SSpwRzqQU4Oj9tss9I=";
               name = "conneroh.com";
               goSum = ./go.sum;
               subPackages = ["."];


### PR DESCRIPTION
## Summary
- update vendor hash for Go module in `flake.nix`

## Testing
- `bun install --ignore-scripts`
- `bun test` *(fails: ReferenceError `document` is not defined)*
- `go test ./...` *(fails: no required module provides package)*

------
https://chatgpt.com/codex/tasks/task_e_6846e2a84fe08333b832def715dfd097