### PR TITLE
Add preview mask styling

### DIFF
--- a/cmd/conneroh/components/items.templ
+++ b/cmd/conneroh/components/items.templ
@@ -22,11 +22,11 @@ templ ProjectItem(
 			{ attrs... }
 		>
 			<div class={ twerge.It("relative w-full") }>
-				@Image(
-					project.BannerPath,
-					project.Title,
-					twerge.It("w-full h-48 object-cover"),
-				)
+                                @Image(
+                                        project.BannerPath,
+                                        project.Title,
+                                        twerge.It("w-full h-48 object-cover preview-mask"),
+                                )
 			</div>
 			<div
 				class={ twerge.It("flex-grow flex p-6 flex-col") }
@@ -88,11 +88,11 @@ templ PostItem(post *assets.Post, attrs templ.Attributes) {
 			aria-label={ post.Title }
 			{ attrs... }
 		>
-			@Image(
-				post.BannerPath,
-				post.Title,
-				twerge.It("w-full h-48 object-cover"),
-			)
+                        @Image(
+                                post.BannerPath,
+                                post.Title,
+                                twerge.It("w-full h-48 object-cover preview-mask"),
+                        )
 			<div
 				class={ twerge.It("p-6") }
 			>
@@ -190,11 +190,11 @@ templ EmploymentItem(employment *assets.Employment, attrs templ.Attributes) {
 			aria-label={ employment.Title }
 			{ attrs... }
 		>
-			@Image(
-				employment.BannerPath,
-				employment.Title,
-				twerge.It("w-full h-48 object-cover"),
-			)
+                        @Image(
+                                employment.BannerPath,
+                                employment.Title,
+                                twerge.It("w-full h-48 object-cover preview-mask"),
+                        )
 			<div
 				class={ twerge.It("p-6") }
 			>

--- a/input.css
+++ b/input.css
@@ -1378,7 +1378,13 @@ div[style*="color:#f8f8f2;background-color:#272822"] td:last-child {
 }
 
 .highlight::-webkit-scrollbar-thumb:hover {
-	background: #777;
+        background: #777;
+}
+
+/* Preview banner mask for dynamic effects */
+.preview-mask {
+        mask: radial-gradient(30px at top,#0000 calc(100% - 1px),#000) 50%/55.5px 100%;
+        -webkit-mask: radial-gradient(30px at top,#0000 calc(100% - 1px),#000) 50%/55.5px 100%;
 }
 
 /* For Firefox */


### PR DESCRIPTION
## Summary
- style banners with a `preview-mask` class using CSS `mask`
- apply the new class to all banner images in item components

## Testing
- `npm test --silent` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1178/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_684d9cd2594c8333bab8f882b4c65eff